### PR TITLE
refactor:项目目录展开收交互优化

### DIFF
--- a/src/components/collapse/index.module.scss
+++ b/src/components/collapse/index.module.scss
@@ -21,7 +21,9 @@
       cursor: pointer;
       .svg {
         fill: hsl(0 0% 80%);
-        margin-right: 5px;
+      }
+      .header-text {
+        padding-left: 5px;
       }
     }
     .header-control {

--- a/src/components/collapse/index.tsx
+++ b/src/components/collapse/index.tsx
@@ -112,7 +112,7 @@ const Collapse = () => {
     height: isCollapsed ? 0 : bounds.height,
   });
   const toggleWrapperAnimatedStyle = useSpring({
-    transform: isCollapsed ? "rotate(0deg)" : "rotate(180deg)",
+    transform: isCollapsed ? "rotate(-90deg)" : "rotate(0deg)"
   });
 
   // 添加文件
@@ -154,7 +154,7 @@ const Collapse = () => {
               ></path>
             </svg>
           </animated.div>
-          <span>FILES</span>
+          <span className={styles["header-text"]}>FILES</span>
         </div>
         <div className={styles["header-control"]}>
           <img


### PR DESCRIPTION

https://github.com/xun082/online-cooperative-edit/assets/38905126/823f6af4-74e0-4b12-b048-838ed0be24ad

如图所示，优化了一个细节交互，展开收起目录左侧的三角形旋转优化了下，目前和vscode的相同，展开时箭头朝下，收起时箭头朝右